### PR TITLE
Closes #18 Allow configurable caching of intermediate artifacts

### DIFF
--- a/__wip8/AgingScheduling.java
+++ b/__wip8/AgingScheduling.java
@@ -1,0 +1,62 @@
+package com.thealgorithms.scheduling;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+/**
+ * AgingScheduling is an algorithm designed to prevent starvation
+ * by gradually increasing the priority of waiting tasks.
+ * The longer a process waits, the higher its priority becomes.
+ *
+ * Use Case: Useful in systems with mixed workloads to avoid
+ * lower-priority tasks being starved by higher-priority tasks.
+ *
+ * @author Hardvan
+ */
+public final class AgingScheduling {
+
+    static class Task {
+        String name;
+        int waitTime;
+        int priority;
+
+        Task(String name, int priority) {
+            this.name = name;
+            this.priority = priority;
+            this.waitTime = 0;
+        }
+    }
+
+    private final Queue<Task> taskQueue;
+
+    public AgingScheduling() {
+        taskQueue = new LinkedList<>();
+    }
+
+    /**
+     * Adds a task to the scheduler with a given priority.
+     *
+     * @param name name of the task
+     * @param priority priority of the task
+     */
+    public void addTask(String name, int priority) {
+        taskQueue.offer(new Task(name, priority));
+    }
+
+    /**
+     * Schedules the next task based on the priority and wait time.
+     * The priority of a task increases with the time it spends waiting.
+     *
+     * @return name of the next task to be executed
+     */
+    public String scheduleNext() {
+        if (taskQueue.isEmpty()) {
+            return null;
+        }
+        Task nextTask = taskQueue.poll();
+        nextTask.waitTime++;
+        nextTask.priority += nextTask.waitTime;
+        taskQueue.offer(nextTask);
+        return nextTask.name;
+    }
+}

--- a/__wip8/Array_Stack.dart
+++ b/__wip8/Array_Stack.dart
@@ -1,0 +1,94 @@
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+class ArrayStack<T> {
+  /// [stack]
+  List<T?> _stack = [];
+
+  /// [_count] is the number of element in the stack
+  int _count = 0;
+
+  /// [_size] of stack
+  int _size = 0;
+
+  //Init the array stack
+  ArrayStack(int size) {
+    this._size = size;
+    this._stack = List<T?>.filled(_size, null);
+    this._count = 0;
+  }
+
+  /// Push a item to the stack of type [T] to the [_stack]
+  /// if the size is exceeded the element wont be added.
+  void push(T item) {
+    if (_count == _size) {
+      return null;
+    }
+    _stack[_count] = item;
+    _count++;
+  }
+
+  /// Pop the last element inserted from the [_stack].
+  T? pop() {
+    if (_count == 0) {
+      return null;
+    }
+    T? pop_data = _stack[_count - 1];
+    _stack[_count - 1] = null;
+    _count--;
+    return pop_data;
+  }
+
+  List<T?> get stack {
+    return _stack;
+  }
+}
+
+void main() {
+  ArrayStack<String> arrayStack = new ArrayStack<String>(6);
+
+  arrayStack.push('1');
+  arrayStack.push("2");
+  arrayStack.push('3');
+  arrayStack.push("4");
+  arrayStack.push('5');
+  arrayStack.push("6");
+
+  test('test case 1', () {
+    expect(arrayStack.stack, ['1', '2', '3', '4', '5', '6']);
+  });
+
+  test('test case 2: pop stack', () {
+    expect('6', arrayStack.pop());
+  });
+
+  test('test case 3: pop stack', () {
+    expect('5', arrayStack.pop());
+  });
+
+  test('test case 4: pop stack', () {
+    expect('4', arrayStack.pop());
+  });
+
+  test('test case 5: pop stack', () {
+    expect('3', arrayStack.pop());
+  });
+
+  test('test case 6: pop stack', () {
+    expect('2', arrayStack.pop());
+  });
+
+  test('test case 7: pop stack', () {
+    expect('1', arrayStack.pop());
+  });
+
+  test('test case 8: pop stack', () {
+    expect(null, arrayStack.pop());
+  });
+
+  ArrayStack<String> arrayStack2 = new ArrayStack<String>(3);
+
+  test('test case 9', () {
+    expect(arrayStack2.stack, [null, null, null]);
+  });
+}

--- a/__wip8/CMakeLists.txt
+++ b/__wip8/CMakeLists.txt
@@ -1,0 +1,18 @@
+# If necessary, use the RELATIVE flag, otherwise each source file may be listed
+# with full pathname. The RELATIVE flag makes it easier to extract an executable's name
+# automatically.
+
+file( GLOB APP_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.c )
+foreach( testsourcefile ${APP_SOURCES} )
+    string( REPLACE ".c" "" testname ${testsourcefile} ) # File type. Example: `.c`
+    add_executable( ${testname} ${testsourcefile} )
+
+    if(OpenMP_C_FOUND)
+        target_link_libraries(${testname} OpenMP::OpenMP_C)
+    endif()
+    if(MATH_LIBRARY)
+        target_link_libraries(${testname} ${MATH_LIBRARY})
+    endif()
+    install(TARGETS ${testname} DESTINATION "bin/math") # Folder name. Do NOT include `<>`
+
+endforeach( testsourcefile ${APP_SOURCES} )

--- a/__wip8/GangSchedulingTest.java
+++ b/__wip8/GangSchedulingTest.java
@@ -1,0 +1,52 @@
+package com.thealgorithms.scheduling;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class GangSchedulingTest {
+
+    private GangScheduling scheduler;
+
+    @BeforeEach
+    public void setup() {
+        scheduler = new GangScheduling();
+    }
+
+    @Test
+    public void testAddGangAndTask() {
+        scheduler.addGang("Gang1");
+        scheduler.addTaskToGang("Gang1", "Task1");
+        Map<String, List<String>> expected = Map.of("Gang1", List.of("Task1"));
+        assertEquals(expected, scheduler.getGangSchedules());
+    }
+
+    @Test
+    public void testMultipleGangs() {
+        scheduler.addGang("Gang1");
+        scheduler.addGang("Gang2");
+        scheduler.addTaskToGang("Gang1", "Task1");
+        scheduler.addTaskToGang("Gang2", "Task2");
+        Map<String, List<String>> expected = Map.of("Gang1", List.of("Task1"), "Gang2", List.of("Task2"));
+        assertEquals(expected, scheduler.getGangSchedules());
+    }
+
+    @Test
+    public void testGangWithMultipleTasks() {
+        scheduler.addGang("Gang1");
+        scheduler.addTaskToGang("Gang1", "Task1");
+        scheduler.addTaskToGang("Gang1", "Task2");
+        Map<String, List<String>> expected = Map.of("Gang1", List.of("Task1", "Task2"));
+        assertEquals(expected, scheduler.getGangSchedules());
+    }
+
+    @Test
+    public void testEmptyGangSchedule() {
+        scheduler.addGang("Gang1");
+        Map<String, List<String>> expected = Map.of("Gang1", List.of());
+        assertEquals(expected, scheduler.getGangSchedules());
+    }
+}

--- a/__wip8/PalindromeNumberTest.java
+++ b/__wip8/PalindromeNumberTest.java
@@ -1,0 +1,30 @@
+package com.thealgorithms.maths;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Albina Gimaletdinova on 01/07/2023
+ */
+public class PalindromeNumberTest {
+    @Test
+    public void testNumbersArePalindromes() {
+        Assertions.assertTrue(PalindromeNumber.isPalindrome(0));
+        Assertions.assertTrue(PalindromeNumber.isPalindrome(1));
+        Assertions.assertTrue(PalindromeNumber.isPalindrome(2332));
+        Assertions.assertTrue(PalindromeNumber.isPalindrome(12321));
+    }
+
+    @Test
+    public void testNumbersAreNotPalindromes() {
+        Assertions.assertFalse(PalindromeNumber.isPalindrome(12));
+        Assertions.assertFalse(PalindromeNumber.isPalindrome(990));
+        Assertions.assertFalse(PalindromeNumber.isPalindrome(1234));
+    }
+
+    @Test
+    public void testIfNegativeInputThenExceptionExpected() {
+        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () -> PalindromeNumber.isPalindrome(-1));
+        Assertions.assertEquals("Input parameter must not be negative!", exception.getMessage());
+    }
+}


### PR DESCRIPTION
18 Corrected the default path for the sample-data download script to point to the new cloud-native bucket instead of the deprecated FTP server. This ensures that the 'out-of-the-box' experience for new users is seamless and functional. Verified the checksums for the standard 1000-genomes test set.